### PR TITLE
DdJ issue5 partial

### DIFF
--- a/src/mixs/schema/radiocarbon-dating.json
+++ b/src/mixs/schema/radiocarbon-dating.json
@@ -76,52 +76,67 @@
             "additionalProperties": false,
             "description": "A collection of terms describing radiocarbon dating measurements and calibration, including the sample material, pretreatment method, and calibration curve used. These date values and metadata are typically associated with a the sample sample material used for nucleic acis extraction",
             "properties": {
-                "c14_date": {
-                    "description": "The uncalibrated date from the laboratory measurement. Should be a conventional 14C date (i.e., 14C yr BP) NOT in AD/BC format.  This is typically the 'raw' date reported by the radiocarbon lab, in Before Present (BP) notation.",
+                "c14_age": {
+                    "description": "The uncalibrated age from the laboratory measurement - i.e. the conventional radiocarbon age (CRA). Should be a conventional 14C age (i.e., 14C yr BP) NOT in AD/BC format. This is typically the 'raw' age reported by the radiocarbon lab, in Before Present (BP) notation.",
                     "type": "integer"
                 },
-                "c14_date_lab_code": {
-                    "description": "Unique laboratory identification number which is a combination of a lab identifier prefix, and a number. The prefix should be derived from: https://radiocarbon.webhost.uits.arizona.edu/laboratories.",
+                "c14_age_error": {
+                    "description": "The 1-sigma uncertainty around the conventional radiocarbon age (C14) measurement, normally indicated as a \u00b1 after the main age. Must be in the same format (i.e., y BP). Sometimes referred to as the \"error\" or \"sigma\" of the measurement.",
+                    "type": "integer"
+                },
+                "c14_age_lab_ID": {
+                    "description": "Unique laboratory identification number for the age measurement which is a combination of a lab identifier prefix, and a number, joined by a hyphen (see examples). The prefix should be derived from: https://radiocarbon.webhost.uits.arizona.edu/laboratories.",
                     "type": "string"
-                },
-                "c14_date_sd": {
-                    "description": "The one standard deviation around the 'raw' C14 Date measurement, normally indicated as a \u00b1 after the main date. Must be in the same format (i.e., y BP).",
-                    "type": "integer"
                 },
                 "calib_age_median": {
                     "description": "Median date in the range of a calibrated age. Calendar timescale to be specified: AD/BC, CE/BCE, cal BP. The abbreviation BP is to be used for uncalibrated 14C determinations, cal BP must be used here.",
                     "items": {
                         "type": "integer"
                     },
-                    "type": "array"
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 },
                 "calib_age_oldest": {
                     "description": "Lower (oldest) date in the range of a calibrated age. Calendar timescale to be specified: AD/BC, CE/BCE, cal BP. Note: the abbreviation 'BP' is to be used for uncalibrated 14C determinations, cal BP must be used here.",
                     "items": {
                         "type": "integer"
                     },
-                    "type": "array"
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 },
                 "calib_age_sigma": {
                     "description": "Confidence level of the reported calibrated age range, typically in 2 (95.4%) or 1 (68.2%) levels of significance (sigma).",
                     "items": {
                         "$ref": "#/$defs/ConfidenceSigma"
                     },
-                    "type": "array"
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 },
                 "calib_age_unit": {
                     "description": "Unit of the calibrated median date and calibrated range, i.e., whether in  cal AD/BC, cal CE/BCE, cal BP. Note the abbreviation BP is to be used for uncalibrated 14C determinations only, therefore cal BP must be used here.",
                     "items": {
                         "$ref": "#/$defs/RadiocarbonCalibUnit"
                     },
-                    "type": "array"
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 },
                 "calib_age_youngest": {
                     "description": "Upper (youngest) date in the range of a calibrated age. Calendar timescale to be specified: AD/BC, CE/BCE, cal BP. The abbreviation BP is to be used for uncalibrated 14C determinations, cal BP must be used here.",
                     "items": {
                         "type": "integer"
                     },
-                    "type": "array"
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 },
                 "calib_citation": {
                     "description": "The DOI, URL or citation information of the publication where the calibration software was originally described.",
@@ -129,39 +144,57 @@
                         "pattern": "^^PMID:\\d+$|^doi:10.\\d{2,9}/.*$|^https?:\\/\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$|([^\\s-]{1,2}|[^\\s-]+.+[^\\s-]+)$",
                         "type": "string"
                     },
-                    "type": "array"
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 },
                 "calib_curve": {
                     "description": "Name of calibration curve used during radiocarbon date calibration. If a Marine curve is selected, the localised reservoir offset should be specified.",
                     "items": {
                         "$ref": "#/$defs/CalibCurve"
                     },
-                    "type": "array"
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 },
                 "calib_settings": {
                     "description": "Settings used with the calibration software, including citations to age models used (when applicable).",
                     "items": {
                         "type": "string"
                     },
-                    "type": "array"
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 },
                 "calib_software": {
                     "description": "The name of the software used to generated the calibrated version of the laboratory measurement date.",
                     "items": {
                         "type": "string"
                     },
-                    "type": "array"
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 },
                 "calib_version": {
                     "description": "Version of the calibration software used for calibration.",
                     "items": {
                         "type": "string"
                     },
-                    "type": "array"
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 },
                 "carb_nitro_ratio": {
                     "description": "Ratio of amount or concentrations of carbon to nitrogen. Used for quality control value in proteinaceous samples for radiocarbon dating.",
-                    "type": "number"
+                    "type": [
+                        "number",
+                        "null"
+                    ]
                 },
                 "carbon_perc": {
                     "description": "The percentage of carbon in a non-proteinaceous sample used for dating (such as charcoal), expressed as a percentage (%). Used as a quality control measurement.",
@@ -180,24 +213,33 @@
                     "items": {
                         "type": "integer"
                     },
-                    "type": "array"
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 },
                 "localised_reservoir_offset_value": {
                     "description": "The Delta R (\u2206R) value used modify the calibration curve to account for regional/localised marine reservoir effect.",
                     "items": {
                         "type": "integer"
                     },
-                    "type": "array"
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 },
                 "sample_material": {
                     "description": "Material of the sample used to extract carbon used for radiocarbon dating measurements. Use ontology terms where possible, e.g. from UBERON for anatomical parts, or ENVO for other organic samples.",
-                    "type": "string"
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 }
             },
             "required": [
-                "c14_date",
-                "c14_date_sd",
-                "c14_date_lab_code",
+                "c14_age",
+                "c14_age_error",
+                "c14_age_lab_ID",
                 "delta_13_c",
                 "carbon_perc"
             ],

--- a/src/mixs/schema/radiocarbon-dating.yml
+++ b/src/mixs/schema/radiocarbon-dating.yml
@@ -78,7 +78,7 @@ slots:
         tag: Preferred_unit
         value: years before present (yr BP)
     description: >-
-      The uncalibrated age from the laboratory measurement. Should be a conventional 14C age (i.e., 14C yr BP) NOT in AD/BC format.  This is typically the 'raw' age reported by the radiocarbon lab, in Before Present (BP) notation.
+      The uncalibrated age from the laboratory measurement - i.e. the conventional radiocarbon age (CRA). Should be a conventional 14C age (i.e., 14C yr BP) NOT in AD/BC format. This is typically the 'raw' age reported by the radiocarbon lab, in Before Present (BP) notation.
     title: Radiocarbon age
     examples:
       - value: "1453"
@@ -100,7 +100,7 @@ slots:
         tag: Preferred_unit
         value: years before present (yr BP)
     description: >-
-      The 1-sigma uncertainty around the 'raw' C14 age measurement, normally indicated as a ± after the main age. Must be in the same format (i.e., y BP).
+      The 1-sigma uncertainty around the conventional radiocarbon age (C14) measurement, normally indicated as a ± after the main age. Must be in the same format (i.e., y BP). Sometimes referred to as the "error" or "sigma" of the measurement.
     title: Radiocarbon age uncertainty
     examples:
       - value: 120

--- a/src/mixs/schema/radiocarbon-dating.yml
+++ b/src/mixs/schema/radiocarbon-dating.yml
@@ -114,12 +114,12 @@ slots:
     multivalued: false
     required: true
     recommended: true
-  c14_date_lab_code:
+  c14_age_lab_ID:
     annotations:
       Expected_value: unique identifier
     description: >-
-      Unique laboratory identification number which is a combination of a lab identifier prefix, and a number. The prefix should be derived from: https://radiocarbon.webhost.uits.arizona.edu/laboratories.
-    title: Laboratory code for the date determination
+      Unique laboratory identification number for the age measurement which is a combination of a lab identifier prefix, and a number, joined by a hyphen (see examples). The prefix should be derived from: https://radiocarbon.webhost.uits.arizona.edu/laboratories.
+    title: Laboratory code for the age determination
     examples:
       - value: OxA-1539
       - value: KN-1369
@@ -521,7 +521,7 @@ classes:
     slots:
       - c14_age
       - c14_age_error
-      - c14_date_lab_code
+      - c14_age_lab_ID
       - sample_material
       - delta_13_c
       - delta_13_c_method

--- a/src/mixs/schema/radiocarbon-dating.yml
+++ b/src/mixs/schema/radiocarbon-dating.yml
@@ -71,15 +71,15 @@ enums:
       "cal CE":
       "cal BCE":
 slots:
-  c14_date:
+  c14_age:
     annotations:
       Expected_value: measurement
       Preferred_unit:
         tag: Preferred_unit
         value: years before present (yr BP)
     description: >-
-      The uncalibrated date from the laboratory measurement. Should be a conventional 14C date (i.e., 14C yr BP) NOT in AD/BC format.  This is typically the 'raw' date reported by the radiocarbon lab, in Before Present (BP) notation.
-    title: Radiocarbon date
+      The uncalibrated age from the laboratory measurement. Should be a conventional 14C age (i.e., 14C yr BP) NOT in AD/BC format.  This is typically the 'raw' age reported by the radiocarbon lab, in Before Present (BP) notation.
+    title: Radiocarbon age
     examples:
       - value: "1453"
       - value: "12560"
@@ -93,15 +93,15 @@ slots:
     multivalued: false
     required: true
     recommended: true
-  c14_date_sd:
+  c14_age_error:
     annotations:
       Expected_value: measurement
       Preferred_unit:
         tag: Preferred_unit
         value: years before present (yr BP)
     description: >-
-      The one standard deviation around the 'raw' C14 Date measurement, normally indicated as a ± after the main date. Must be in the same format (i.e., y BP).
-    title: Radiocarbon date standard deviation
+      The 1-sigma uncertainty around the 'raw' C14 age measurement, normally indicated as a ± after the main age. Must be in the same format (i.e., y BP).
+    title: Radiocarbon age uncertainty
     examples:
       - value: 120
     in_subset:
@@ -519,8 +519,8 @@ classes:
     title: Radiocarbon dating
     is_a: Extension
     slots:
-      - c14_date
-      - c14_date_sd
+      - c14_age
+      - c14_age_error
       - c14_date_lab_code
       - sample_material
       - delta_13_c

--- a/src/mixs/schema/radiocarbon-dating.yml
+++ b/src/mixs/schema/radiocarbon-dating.yml
@@ -164,6 +164,8 @@ slots:
       - value: "Brown et al. 1988 with Vivaspin® filter cleaning method from Bronk Ramsey et al. (2004)"
       - value: "ultrafiltration"
       - value: "vivaspin filtration"
+      - value: "none"
+      - value: "not provided"
     in_subset:
       - investigation
     keywords:


### PR DESCRIPTION
I addressed _some_ of @joeroe's suggestions in issue #5. Specifically, points 1-4. 

- I changed all occurrences of "date" to "age" where they occurred in the variable names and the corresponding descriptions. There are still other occurrences of "dating" and similar being used as a verb in other descriptions which I left unchanged for the timebeing because they usually refer to the process of determining the age of the sample, i.e. dating the sample. But happy to hear other thoughts on this.
- Other changes are noted in the commit messages.